### PR TITLE
Use https instead of ssh to checkout submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "proto"]
 	path = proto
-	url = git@github.com:grammatek/tts-frontend-api.git
+	url = https://github.com/grammatek/tts-frontend-api.git
 [submodule "normalizer"]
 	path = src/regina_normalizer
-	url = git@github.com:grammatek/regina_normalizer.git
+	url = https://github.com/grammatek/regina_normalizer.git


### PR DESCRIPTION
Note that this can be overridden by a user's .gitconfig, like so:

     [url "git@github.com:grammatek/"]
	insteadOf = https://github.com/grammatek/