### PR TITLE
Use relative path for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tts-frontend-proto"]
 	path = tts-frontend-proto
-	url = https://github.com/grammatek/tts-frontend-proto.git
+	url = ../tts-frontend-proto.git


### PR DESCRIPTION
Use relative path for git submodule, otherwise authentication problems when cloning and updating the submodules

Reference:

https://www.damirscorner.com/blog/posts/20210423-ChangingUrlsOfGitSubmodules.html